### PR TITLE
Fix tests on JRuby

### DIFF
--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -188,9 +188,9 @@ class TestHoe < MiniTest::Unit::TestCase
       end
     end
 
-    assert_match(/^sudo gem.*/, hoe.install_gem('foo'))
+    assert_match(/^sudo j?gem.*/, hoe.install_gem('foo'))
     ENV['NOSUDO'] = '1'
-    assert_match(/^gem.*/, hoe.install_gem('foo'))
+    assert_match(/^j?gem.*/, hoe.install_gem('foo'))
   ensure
     ENV.delete "NOSUDO"
   end


### PR DESCRIPTION
One of the tests was [failing on JRuby](http://test.rubygems.org/gems/hoe/v/2.9.4/test_results/1104) because the regular expression didn't match "jgem" instead of "gem". This patch updates the regular expression to allow either "gem" or "jgem".
