### PR TITLE
Manifest is read in with binary encoding

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -422,7 +422,9 @@ class Hoe
     self.spec = Gem::Specification.new do |s|
       dirs = Dir['lib']
 
-      manifest = File.read_utf("Manifest.txt").split(/\r?\n\r?/) rescue nil
+      manifest = File.open("Manifest.txt", "r:bom|utf-8") { |f|
+        f.read
+      }.split(/\r?\n\r?/u) rescue nil
 
       abort [
              "Manifest is missing or couldn't be read.",

--- a/lib/hoe/test.rb
+++ b/lib/hoe/test.rb
@@ -117,7 +117,11 @@ module Hoe::Test
       # more information, see: <https://github.com/erikh/rubygems-test>
       # and/or <http://www.gem-testers.org/>
 
-      self.spec.files += [".gemtest"]
+      gemtest = ".gemtest"
+
+      gemtest.encode!(Encoding::UTF_8) if gemtest.respond_to?(:encoding)
+
+      self.spec.files += [gemtest]
 
       pkg  = pkg_path
       turd = "#{pkg}/.gemtest"

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -21,6 +21,14 @@ class TestHoe < MiniTest::Unit::TestCase
     Rake.application.clear
   end
 
+  def test_read_utf_encoding
+    skip "encoding not supported" unless "<3".respond_to?(:encoding)
+
+    hoe.spec.files.each do |file_name|
+      assert_equal Encoding::UTF_8, file_name.encoding
+    end
+  end
+
   def test_class_load_plugins
     loaded, = Hoe.load_plugins
 


### PR DESCRIPTION
The manifest is read in as binary.  This patch makes the manifest read in as UTF-8.  I'm not sure UTF-8 is the correct solution because the manifest is meant to keep a list of filenames.  The filename encoding probably depends on the encoding of the filesystem.

Though, I'd argue it's best to standardize on utf-8 because probably not everyone will have the same filesystem encoding, and that means the manifest would not work correctly.
