### PR TITLE
Add support for per-project .hoerc overrides

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -746,13 +746,18 @@ class Hoe
   end
 
   ##
-  # Loads ~/.hoerc and yields the configuration and its path
+  # Loads ~/.hoerc, merges it with a .hoerc in the current pwd (if any) and yields the 
+  # configuration and its path
 
   def with_config
     rc = File.expand_path("~/.hoerc")
     exists = File.exist? rc
     config = exists ? YAML.load_file(rc) : {}
-    yield(config, rc)
+    localrc = File.join Dir.pwd, '.hoerc'
+    exists = File.exist? localrc
+    localconfig = exists ? YAML.load_file(localrc) : {}
+
+    yield(config.merge(localconfig), rc)
   end
 end
 

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -70,6 +70,35 @@ class TestHoe < MiniTest::Unit::TestCase
     ENV['HOME'] = home
   end
 
+  def test_perproject_hoerc
+    overrides = {
+      'exclude' => Regexp.union( Hoe::DEFAULT_CONFIG["exclude"], /\.hg/ ),
+      'plugins' => ['tweedledee', 'tweedledum']
+    }
+    overrides_rcfile = File.join(Dir.pwd, '.hoerc')
+
+    home = ENV['HOME']
+    Hoe.files = nil
+
+    Dir.mktmpdir do |path|
+      ENV['HOME'] = path
+
+      open File.join(path, '.hoerc'), 'w' do |io|
+        io.write YAML.dump( Hoe::DEFAULT_CONFIG )
+      end
+      open overrides_rcfile, File::CREAT|File::EXCL|File::WRONLY do |io|
+        io.write YAML.dump( overrides )
+      end
+
+      hoeconfig = hoe.with_config {|config, _| config }
+
+      assert_equal Hoe::DEFAULT_CONFIG.merge(overrides), hoeconfig
+    end
+  ensure
+    File.delete overrides_rcfile if File.exist?( overrides_rcfile )
+    ENV['HOME'] = home
+  end
+
   def test_initialize_plugins_hoerc
     home = ENV['HOME']
     load_path = $LOAD_PATH.dup


### PR DESCRIPTION
Hi!

I have found myself changing my ~/.hoerc around for different projects (work vs. personal, etc.), especially the 'exclude' pattern and the path to the signing key, and I found myself wanting a per-project .hoerc that could be used to override keys of the global ~/.hoerc.

This patch adds that feature along with a test for it. I considered trying to do a fancier sort of merge, but that wound up being pretty complex and probably counter-intuitive.

Thanks for considering it, and again for Hoe.
