### PR TITLE
Missing dependency to path for .gemtest creation task

### DIFF
--- a/lib/hoe/test.rb
+++ b/lib/hoe/test.rb
@@ -126,7 +126,7 @@ module Hoe::Test
       pkg  = pkg_path
       turd = "#{pkg}/.gemtest"
 
-      file turd do
+      file turd => pkg_path do
         touch turd
       end
 


### PR DESCRIPTION
When running parallel tasks with drake, a packaging task fails, because of a missing dependency.

$ drake -j12 gem MAKE="make -j12" 
rake aborted!
No such file or directory - pkg/fxruby-1.6.23/.gemtest

The attached patch fixes it.
