### PR TITLE
rbx in 1.9 mode does not support the bom|utf-8 encoding

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -834,10 +834,10 @@ class File
   # Like File::read, but strips out a BOM marker if it exists.
   def self.read_utf path
     r19 = "<3".respond_to? :encoding
-    opt = r19 ? "r:bom|utf-8" : "rb"
+    opt = (r19 && RUBY_ENGINE != 'rbx')  ? "r:bom|utf-8" : "rb"
 
     open path, opt do |f|
-      if r19 then
+      if r19 && RUBY_ENGINE != 'rbx' then
         f.read
       else
         f.read.sub %r/\A\xEF\xBB\xBF/, ''

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -221,7 +221,7 @@ class TestHoe < MiniTest::Unit::TestCase
       content = File.read_utf io.path
       assert_equal 'BOM', content
 
-      if content.respond_to? :encoding then
+      if content.respond_to?(:encoding) && RUBY_ENGINE != 'rbx' then
         assert_equal Encoding::UTF_8, content.encoding
       end
     end


### PR DESCRIPTION
This is kind of a hack, but I did not find a way to get rubinius in 1.9 mode to work.
