### PR TITLE
fix ridocs argument handling

### DIFF
--- a/lib/hoe/publish.rb
+++ b/lib/hoe/publish.rb
@@ -126,7 +126,7 @@ module Hoe::Publish
 
       desc 'Generate ri locally for testing.'
       task :ridocs => [:clean, :isolate] do
-        ruby make_rdoc_cmd "--ri -o ri"
+        ruby(*make_rdoc_cmd("--ri -o ri"))
       end
     end
 


### PR DESCRIPTION
small fix for ridocs task argument handling. the original command actually outputs the inspect data to the shell call to ruby which obviously does not work so hot.

So, there's still an issue here, and I'm working on rdoc so I'm willing to bet it's something related to my patches. It doesn't generate ri at all, but instead generates rdoc to the doc directory. I'm pretty sure it has something to do with the -o flag done so prematurely but I don't want to discount the fact that my rdoc branch is still in development.

I hope this patch helps. Have a nice day.
