### PR TITLE
Workaround for rubinius/rubinius#1766

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -841,10 +841,20 @@ class File
     r19 = "<3".respond_to? :encoding
     opt = r19 ? "r:bom|utf-8" : "rb"
 
-    open path, opt do |f|
-      if r19 then
-        f.read
-      else
+    if r19 then
+      begin
+        open path, "r:bom|utf-8" do |f|
+          f.read
+        end
+      rescue ArgumentError
+
+        # workaround for rubinius#1766
+        open path, "r" do |f|
+          f.read.sub(%r/\A\xEF\xBB\xBF/, '').encode "utf-8"
+        end
+      end
+    else
+      open path, opt do |f|
         f.read.sub %r/\A\xEF\xBB\xBF/, ''
       end
     end


### PR DESCRIPTION
Rubinius has a bug in `open`.  This results in the following error.
See https://github.com/rubinius/rubinius/issues/1766 .

```
** README.md is missing or in the wrong format for auto-intuiting.
   run `sow blah` and look at its text files
** History.txt is missing or in the wrong format for auto-intuiting.
   run `sow blah` and look at its text files
Manifest is missing or couldn't be read.
The Manifest is kind of a big deal.
Maybe you're using a gem packaged by a linux project.
It seems like they enjoy breaking other people's code.
```

This patch is workaround for the problem of `File.read_utf`.
I tested with rbx-head (1.9 compatible), MRI 1.8.7, MRI 1.9.3.
