### PR TITLE
Fix test failure with rake 0.8.7

### DIFF
--- a/test/test_hoe_debug.rb
+++ b/test/test_hoe_debug.rb
@@ -8,6 +8,10 @@ class TestHoeDebug < MiniTest::Unit::TestCase
 
   include Hoe::Debug
 
+  #On Rake 0.8.7 verbose_flag is true, with cause two
+  #tests here to fail. Fix issue #31
+  RakeFileUtils.verbose_flag = nil
+
   attr_accessor :generated_files
 
   def setup


### PR DESCRIPTION
On rake 0.8.7 the verbose_flag is set to true, which makes two tests to fail.
