### PR TITLE
Fix "rake ridocs" command arguments

### DIFF
--- a/lib/hoe/publish.rb
+++ b/lib/hoe/publish.rb
@@ -126,7 +126,7 @@ module Hoe::Publish
 
       desc 'Generate ri locally for testing.'
       task :ridocs => [:clean, :isolate] do
-        ruby(*make_rdoc_cmd("--ri -o ri"))
+        ruby(*make_rdoc_cmd('--ri', '-o', 'ri'))
       end
     end
 


### PR DESCRIPTION
the "--ri -o ri" was being interpreted as a single argument.
### before patch:

```
$ rake ridocs                                                              
rm -rf doc
rm -r pkg
rm -rf ri
/Users/ned/.rvm/rubies/ruby-1.9.3-head/bin/ruby /Users/ned/.rvm/gems/ruby-1.9.3-head/bin/rdoc --title zonk's Zonk-1.0.0 Documentation -o doc --main README.txt --ri -o ri lib History.txt Manifest.txt README.txt
invalid options: --ri -o ri
(invalid options are ignored)
Parsing sources...
100% [12/12]  README.txt                                                        

Generating Darkfish format into /Users/ned/Dropbox/Zonk/Zonk/doc...
```
### after patch:

```
$ rake ridocs                                                                                        
rm -rf doc
rm -r pkg
/Users/ned/.rvm/rubies/ruby-1.9.3-head/bin/ruby /Users/ned/.rvm/gems/ruby-1.9.3-head/bin/rdoc --title zonk's Zonk-1.0.0 Documentation -o doc --main README.txt --ri -o ri lib History.txt Manifest.txt README.txt
Parsing sources...
100% [12/12]  README.txt                                                        

Generating RI format into /Users/ned/Dropbox/Zonk/Zonk/ri...
```
