### PR TITLE
update deps from ~0.8 to >= 0.8 && < 11.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ Hoe.spec "hoe" do
   pluggable!
   require_rubygems_version '>= 1.4'
 
-  dependency "rake", "~> 0.8" # FIX: to force it to exist pre-isolate
+  dependency "rake", [">= 0.8", "< 11.0"] # FIX: to force it to exist pre-isolate
 end
 
 task :plugins do


### PR DESCRIPTION
I guess Jim got sick of people bugging him about getting to rake 1.0 so he bumped to version 10. From the documentation, the only real changes were that the deprecations it gathered over the years were officially dropped.

I updated the deps and ran the specs while using rake 10 and they all passed. Let me know if there is any more thorough testing you need me to do (and how) and I'll be happy to do them.

I'll be sending another pull request for vlad.
