### PR TITLE
Fixing typo in testfile ERB

### DIFF
--- a/template/test/file_name.rb.erb
+++ b/template/test/file_name.rb.erb
@@ -2,7 +2,7 @@ require "minitest/autorun"
 require "<%= file_name %>"
 
 <%= make_sub_modules test_klass %>
-class <%= test_klass %> < Minitest::Unit::TestCase
+class <%= test_klass %> < MiniTest::Unit::TestCase
   def test_sanity
     flunk "write tests or I will kneecap you"
   end


### PR DESCRIPTION
Hey Ryan (or whomever):

I just got Hoe installed on rvm ruby 1.9.3, used sow, ran autotest, saw it choke on 'Minitest::Unit::TestCase'. Attached is a fix for the typo to 'MiniTest'.

I looked through the tests for Hoe and saw nothing validating the ERB templates or their output. Would it make sense to have some tests that simulate creating a simple project and loading each of the output classes to make sure nothing blows up?
