### PR TITLE
Upgrade test command generator for Ruby 1.9 compatibility

### DIFF
--- a/lib/hoe/test.rb
+++ b/lib/hoe/test.rb
@@ -153,7 +153,7 @@ module Hoe::Test
 
     tests = ["rubygems"]
     tests << framework if framework
-    tests << test_globs.sort.map { |g| Dir.glob(g) }
+    tests << test_globs.sort.map { |g| Dir.glob(g).map{ |f| './' + f.gsub(/\.rb$/, '') } } }
     tests.flatten!
     tests.map! {|f| %(require "#{f}")}
 


### PR DESCRIPTION
The Hoe test cmd generator is not compatible with Ruby 1.9, e.g

```
/Users/rongz/.rvm/rubies/ruby-1.9.3-p392/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; gem "minitest"; require "minitest/autorun"; require "test/gtg/test_builder.rb"; require "test/gtg/test_transition_table.rb"; require "test/nfa/test_simulator.rb"; require "test/nfa/test_transition_table.rb"; require "test/nodes/test_symbol.rb"; require "test/path/test_pattern.rb"; require "test/route/definition/test_parser.rb"; require "test/route/definition/test_scanner.rb"; require "test/router/test_strexp.rb"; require "test/router/test_utils.rb"; require "test/test_route.rb"; require "test/test_router.rb"; require "test/test_routes.rb"' --
```

This command, which is generated by journey won't work with Ruby 1.9 because of 2 reasons:
1. current working directory is not in $LOAD_PATH now
2. Do not append ".rb" to the required file

This patch is to solve this problem.
