### PR TITLE
Put proper minitest plugin declaration in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require './lib/hoe.rb'
 
 Hoe.plugin :seattlerb
 Hoe.plugin :isolate
+Hoe.plugin :minitest
 
 Hoe.spec "hoe" do
   developer "Ryan Davis", "ryand-ruby@zenspider.com"


### PR DESCRIPTION
Now the unit tests pass on my Mac.

```
$ rake test
/usr/local/Cellar/ruby/1.9.3-p385/bin/ruby -w -Ilib:bin:test:. -e 'require "rubygems"; gem "minitest"; require "minitest/autorun"; require "test/test_hoe_test.rb"; require "test/test_hoe.rb"; require "test/test_hoe_debug.rb"; require "test/test_hoe_gemcutter.rb"; require "test/test_hoe_publish.rb"; require "test/test_hoe_test.rb"' -- 
Run options: --seed 13050

# Running tests:

.............................

Finished tests in 0.695548s, 41.6937 tests/s, 130.8321 assertions/s.

29 tests, 91 assertions, 0 failures, 0 errors, 0 skips
```
