### PR TITLE
Don't use Bash extended redirect syntax

### DIFF
--- a/lib/hoe/package.rb
+++ b/lib/hoe/package.rb
@@ -89,7 +89,7 @@ module Hoe::Package
 
   def install_gem name, version = nil, rdoc=true
     should_not_sudo = Hoe::WINDOZE || ENV["NOSUDO"] || File.writable?(Gem.dir)
-    null_dev = Hoe::WINDOZE ? '> NUL 2>&1' : '&> /dev/null'
+    null_dev = Hoe::WINDOZE ? '> NUL 2>&1' : '> /dev/null 2>&1'
 
     gem_cmd = Gem.default_exec_format % 'gem'
     sudo    = 'sudo '                  unless should_not_sudo


### PR DESCRIPTION
"&>PATH" is Bash extended redirect syntax.

See also: http://www.gnu.org/software/bash/manual/bashref.html#Redirecting-Standard-Output-and-Standard-Error

It is not worked well on normal sh such as dash. dash is the /bin/sh
on Debian GNU/Linux. If dash is used for "system", "gem install ..."
is run in background. "system" for background command always returns
true:

```
% ruby -e 'p system("nonexsitent &")'
true
sh: 1: nonexsitent: not found
% ruby -e 'p system("nonexsitent")'
nil
```

It means "install_gem" always returns true. It breaks the following
logic in lib/hoe/deps.rb:

```
install_gem("hoe-#{name}", version, false) or
  install_gem(name, version, false) or
  install_gem(dash_name, version, false) or
  warn "could not install gem for #{name} plugin"
```

It causes a problem for "kpeg" gem. "hoe-kpeg" gem doesn't
exist. "kpeg" gem should be searched as fallback but it is not
searched. Because install_gem("hoe-#{name}") is not failed.

RDoc depends on "kpeg". So "rake newb" for RDoc is failed.
