### PR TITLE
Fix up location of Rakefile.erb in itself

### DIFF
--- a/template/Rakefile.erb
+++ b/template/Rakefile.erb
@@ -10,7 +10,7 @@ require "hoe"
 %>
 
 Hoe.spec "<%= project %>" do
-  # HEY! If you fill these out in ~/.hoe_template/Rakefile.erb then
+  # HEY! If you fill these out in ~/.hoe_template/default/Rakefile.erb then
   # you'll never have to touch them again!
   # (delete this comment too, of course)
 


### PR DESCRIPTION
When I first used `sow` the Rakefile template was installed in `~/.hoe_template/default/Rakefile.erb`, but in its comments it claimed it could be found in `~/.hoe_template/Rakefile.erb`

This commit brings the comment in line with reality.
