### PR TITLE
Constrain rubyforge specification.

### DIFF
--- a/lib/hoe/rubyforge.rb
+++ b/lib/hoe/rubyforge.rb
@@ -12,7 +12,8 @@ module Hoe::RubyForge
   def initialize_rubyforge # :nodoc:
     require 'rubyforge'
 
-    dependency_target << ['rubyforge', ">= #{::RubyForge::VERSION}"]
+    dependency_target << ['rubyforge', ["~> #{::RubyForge::VERSION}",
+                                        ">= #{::RubyForge::VERSION}"]]
   end
 
   def define_rubyforge_tasks # :nodoc:


### PR DESCRIPTION
- When building a gem that depends on the rubyforge plug-in, the warning below is produced by RubyGems:

```
    WARNING:  open-ended dependency on rubyforge (>= 2.0.4, development) is not recommended
      if rubyforge is semantically versioned, use:
        add_development_dependency 'rubyforge', '~> 2.0', '>= 2.0.4'
    WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

This change silences this warning.
