### PR TITLE
Added test_name local in ERB templates.

### DIFF
--- a/bin/sow
+++ b/bin/sow
@@ -89,7 +89,7 @@ project = ARGV.shift
 abort op.to_s unless project
 abort "Project #{project} seems to exist" if test ?d, project
 
-_, file_name, klass, test_klass = Hoe.normalize_names project
+_, file_name, test_name, klass, test_klass = Hoe.normalize_names project
 
 klass = klass           # quell unused warnings if they're not used in templates
 test_klass = test_klass # ditto

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -348,8 +348,11 @@ class Hoe
     klass      = klass.  gsub(/(?:^|-)([a-z])/) { "::#{$1.upcase}" }
     test_klass = klass.  gsub(/(^|::)([A-Z])/) { "#{$1}Test#{$2}" }
     file_name  = project.gsub(/-/, '/')
+    test_name  = project.gsub(/-/, '/').split(/\//)
+    test_name[-1] = "test_#{test_name.last}"
+    test_name  = test_name.join('/')
 
-    return project, file_name, klass, test_klass
+    return project, file_name, test_name, klass, test_klass
   end
 
   ##

--- a/template/Manifest.txt.erb
+++ b/template/Manifest.txt.erb
@@ -5,4 +5,4 @@ README.txt
 Rakefile
 bin/<%= file_name %>
 lib/<%= file_name %>.rb
-test/test_<%= file_name %>.rb
+test/<%= test_name %>.rb

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -336,12 +336,12 @@ class TestHoe < Minitest::Test
   def test_rename
     # project, file_name, klass, test_klass = Hoe.normalize_names 'project_name'
 
-    assert_equal %w(    word      word     Word    TestWord),           Hoe.normalize_names('word')
-    assert_equal %w(    word      word     Word    TestWord),           Hoe.normalize_names('Word')
-    assert_equal %w(two_words two_words TwoWords   TestTwoWords),       Hoe.normalize_names('TwoWords')
-    assert_equal %w(two_words two_words TwoWords   TestTwoWords),       Hoe.normalize_names('twoWords')
-    assert_equal %w(two-words two/words Two::Words TestTwo::TestWords), Hoe.normalize_names('two-words')
-    assert_equal %w(two_words two_words TwoWords   TestTwoWords),       Hoe.normalize_names('two_words')
+    assert_equal %w(    word      word     test_word     Word    TestWord),           Hoe.normalize_names('word')
+    assert_equal %w(    word      word     test_word     Word    TestWord),           Hoe.normalize_names('Word')
+    assert_equal %w(two_words two_words test_two_words TwoWords   TestTwoWords),       Hoe.normalize_names('TwoWords')
+    assert_equal %w(two_words two_words test_two_words TwoWords   TestTwoWords),       Hoe.normalize_names('twoWords')
+    assert_equal %w(two-words two/words two/test_words Two::Words TestTwo::TestWords), Hoe.normalize_names('two-words')
+    assert_equal %w(two_words two_words test_two_words TwoWords   TestTwoWords),       Hoe.normalize_names('two_words')
   end
 
   def test_nosudo


### PR DESCRIPTION
Resolves an issue where test_ was being prepended to the entire file path in Manifest.txt, rather than just to the name of the base file.
