### PR TITLE
- Fix PRERELEASE= for packaging

### DIFF
--- a/lib/hoe/package.rb
+++ b/lib/hoe/package.rb
@@ -109,7 +109,7 @@ module Hoe::Package
 
     return unless pre
 
-    spec.version.version << "." << pre if pre
+    spec.version = "#{spec.version}.#{pre}"
 
     abort "ERROR: You should format PRE like pre or alpha.1 or something" if
       (Gem::VERSION < "1.4"  and pre !~ /^[a-z]+(\.\d+)?$/) or

--- a/test/test_hoe_package.rb
+++ b/test/test_hoe_package.rb
@@ -1,0 +1,58 @@
+Hoe.load_plugins
+
+class TestHoePackage < Minitest::Test
+  def setup
+    @orig_PRE        = ENV['PRE']
+    @orig_PRERELEASE = ENV['PRERELEASE']
+
+    ENV.delete 'PRE'
+    ENV.delete 'PRERELEASE'
+
+    @tester = Module.new do
+      include Hoe::Package
+
+      extend self
+
+      initialize_package
+
+      @spec = Gem::Specification.new do |s|
+        s.version = '1.2.3'
+      end
+
+      attr_reader :spec
+    end
+  end
+
+  def teardown
+    ENV['PRE']        = @orig_PRE
+    ENV['PRERELEASE'] = @orig_PRERELEASE
+  end
+
+  def test_prerelease_version_pre
+    ENV['PRE'] = 'pre.0'
+
+    @tester.prerelease_version
+
+    expected = Gem::Version.new '1.2.3.pre.0'
+
+    assert_equal expected, @tester.spec.version
+  end
+
+  def test_prerelease_version_prerelease
+    ENV['PRERELEASE'] = 'prerelease.0'
+
+    @tester.prerelease_version
+
+    expected = Gem::Version.new '1.2.3.prerelease.0'
+
+    assert_equal expected, @tester.spec.version
+  end
+
+  def test_prerelease_version_regular
+    @tester.prerelease_version
+
+    expected = Gem::Version.new '1.2.3'
+
+    assert_equal expected, @tester.spec.version
+  end
+end


### PR DESCRIPTION
RubyGems no longer allows us to append to a version's version string.
We now set the spec's version to a new version object instead.