### PR TITLE
Relax rake version to 11

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Hoe.spec "hoe" do
   pluggable!
   require_rubygems_version ">= 1.4"
 
-  dependency "rake", [">= 0.8", "< 11.0"] # FIX: to force it to exist pre-isolate
+  dependency "rake", [">= 0.8", "< 12.0"] # FIX: to force it to exist pre-isolate
 end
 
 task :plugins do


### PR DESCRIPTION
I released Rake 11 in this week. Please expand rake version of hoe. I got activation error with some gems using hoe.