### PR TITLE
Fixed RDOC dependency for 5.0.0

### DIFF
--- a/lib/hoe/publish.rb
+++ b/lib/hoe/publish.rb
@@ -100,7 +100,7 @@ module Hoe::Publish
   # Declare a dependency on rdoc, IF NEEDED.
 
   def activate_publish_deps
-    dependency "rdoc", "~> 4.0", :developer if need_rdoc
+    dependency "rdoc", ">= 4.0", :developer if need_rdoc
   end
 
   ##


### PR DESCRIPTION
This PR is to fix a dependency issue with RDoc 5.0.0.
`rake newb` was broken.
With this fix everything works again.
