### PR TITLE
Add support for gemspec metadata

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,6 +5,7 @@ code  :: https://github.com/seattlerb/hoe
 bugs  :: https://github.com/seattlerb/hoe/issues
 rdoc  :: http://docs.seattlerb.org/hoe/
 doco  :: http://docs.seattlerb.org/hoe/Hoe.pdf
+clog  :: https://github.com/seattlerb/hoe/blob/master/History.rdoc
 other :: http://github.com/jbarnette/hoe-plugin-examples
 
 == DESCRIPTION:

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -111,6 +111,10 @@ class Hoe
 
   RUBY_FLAGS = ENV["RUBY_FLAGS"] || default_ruby_flags
 
+  ##
+  # Map from the commonly used url names to gemspec's metadata keys
+  # See https://guides.rubygems.org/specification-reference/#metadata
+
   URLS_TO_META_MAP = {
     "bugs" => "bug_tracker_uri",
     "clog" => "changelog_uri",

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -197,6 +197,13 @@ class Hoe
   attr_accessor :name
 
   ##
+  # Optional: Metadata entries
+  #
+  # Set via Hoe.spec.
+
+  attr_accessor :metadata
+
+  ##
   # Optional: A post-install message to be displayed when gem is installed.
 
   attr_accessor :post_install_message
@@ -536,6 +543,13 @@ class Hoe
       s.require_paths        = dirs unless dirs.empty?
       s.rdoc_options         = ["--main", readme_file]
       s.post_install_message = post_install_message
+      s.metadata             = {}.tap do |meta|
+        meta["bug_tracker_uri"] = urls["bugs"] if urls["bugs"]
+        meta["changelog_uri"] = urls["clog"] if urls["clog"]
+        meta["documentation_uri"] = urls["doco"] if urls["doco"]
+        meta["homepage_uri"] = urls["home"] if urls["home"]
+        meta["source_code_uri"] = urls["code"] if urls["code"]
+      end
 
       missing "Manifest.txt" if s.files.empty?
 
@@ -631,6 +645,7 @@ class Hoe
     self.extra_dev_deps       = []
     self.extra_rdoc_files     = []
     self.licenses             = []
+    self.metadata             = {}
     self.post_install_message = nil
     self.group_name           = name.downcase
     self.spec                 = nil

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -209,13 +209,6 @@ class Hoe
   attr_accessor :name
 
   ##
-  # Optional: Metadata entries
-  #
-  # Set via Hoe.spec.
-
-  attr_accessor :metadata
-
-  ##
   # Optional: A post-install message to be displayed when gem is installed.
 
   attr_accessor :post_install_message
@@ -653,7 +646,6 @@ class Hoe
     self.extra_dev_deps       = []
     self.extra_rdoc_files     = []
     self.licenses             = []
-    self.metadata             = {}
     self.post_install_message = nil
     self.group_name           = name.downcase
     self.spec                 = nil

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -111,6 +111,14 @@ class Hoe
 
   RUBY_FLAGS = ENV["RUBY_FLAGS"] || default_ruby_flags
 
+  URLS_TO_META_MAP = {
+    "bugs" => "bug_tracker_uri",
+    "clog" => "changelog_uri",
+    "doco" => "documentation_uri",
+    "home" => "homepage_uri",
+    "code" => "source_code_uri",
+  }
+
   ##
   # Default configuration values for .hoerc. Plugins should populate
   # this on load.
@@ -543,13 +551,9 @@ class Hoe
       s.require_paths        = dirs unless dirs.empty?
       s.rdoc_options         = ["--main", readme_file]
       s.post_install_message = post_install_message
-      s.metadata             = {}.tap do |meta|
-        meta["bug_tracker_uri"]   = urls["bugs"] if urls["bugs"]
-        meta["changelog_uri"]     = urls["clog"] if urls["clog"]
-        meta["documentation_uri"] = urls["doco"] if urls["doco"]
-        meta["homepage_uri"]      = urls["home"] if urls["home"]
-        meta["source_code_uri"]   = urls["code"] if urls["code"]
-      end
+      s.metadata             = urls.select { |name, _| URLS_TO_META_MAP.key? name }.map { |name, link|
+        [URLS_TO_META_MAP[name], link]
+      }.to_h
 
       missing "Manifest.txt" if s.files.empty?
 

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -544,11 +544,11 @@ class Hoe
       s.rdoc_options         = ["--main", readme_file]
       s.post_install_message = post_install_message
       s.metadata             = {}.tap do |meta|
-        meta["bug_tracker_uri"] = urls["bugs"] if urls["bugs"]
-        meta["changelog_uri"] = urls["clog"] if urls["clog"]
+        meta["bug_tracker_uri"]   = urls["bugs"] if urls["bugs"]
+        meta["changelog_uri"]     = urls["clog"] if urls["clog"]
         meta["documentation_uri"] = urls["doco"] if urls["doco"]
-        meta["homepage_uri"] = urls["home"] if urls["home"]
-        meta["source_code_uri"] = urls["code"] if urls["code"]
+        meta["homepage_uri"]      = urls["home"] if urls["home"]
+        meta["source_code_uri"]   = urls["code"] if urls["code"]
       end
 
       missing "Manifest.txt" if s.files.empty?

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -244,6 +244,7 @@ class TestHoe < Minitest::Test
       "bugs"  => "https://github.com/seattlerb/hoe/issues",
       "rdoc"  => "http://docs.seattlerb.org/hoe/",
       "doco"  => "http://docs.seattlerb.org/hoe/Hoe.pdf",
+      "clog"  => "https://github.com/seattlerb/hoe/blob/master/History.rdoc",
       "other" => "http://github.com/jbarnette/hoe-plugin-examples",
     }
 


### PR DESCRIPTION
Add metadata to the produced gemspecs and convert existing urls into the
appropriate entries.
Also add the changelog entry for the hoe project.