### PR TITLE
Allow installing gems without docs in RubyGems 3+

### DIFF
--- a/lib/hoe/package.rb
+++ b/lib/hoe/package.rb
@@ -97,7 +97,7 @@ module Hoe::Package
     version = "--version '#{version}'" if     version
 
     cmd  = "#{sudo}#{gem_cmd} install #{local} #{name} #{version}"
-    cmd += " --no-rdoc --no-ri" unless rdoc
+    cmd += " --no-document" unless rdoc
     cmd += " #{null_dev}" unless Rake.application.options.trace
 
     puts cmd if Rake.application.options.trace


### PR DESCRIPTION
In RubyGems 2.0.0 (end of 2012) --no-document was added for installing
gems without generating documentation.  RubyGems 3.0.0 no longer
supports the old way, --no-rdoc --no-ri.

RubyGems 1.x is very old now and it's probably OK to drop it.