### PR TITLE
sow: update to Ruby 2.6

### DIFF
--- a/bin/sow
+++ b/bin/sow
@@ -117,7 +117,11 @@ Dir.chdir project do
     warn "erb: #{path}"
 
     File.open path, "w" do |io|
-      erb = ERB.new file, nil, "<>"
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        erb = ERB.new file, trim_mode: "<>"
+      else
+        erb = ERB.new file, nil, "<>"
+      end
       erb.filename = path
       io.puts erb.result(binding)
     end


### PR DESCRIPTION
Calling sow with Ruby 2.6 generates the following warning:

  sow:120: warning: Passing safe_level with the 2nd argument of ERB.new is
  deprecated. Do not use it, and specify other arguments as keyword
  arguments.
  sow:120: warning: Passing trim_mode with the 3rd argument of ERB.new is
  deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
  instead.

As it is explained in the release notes:

> Passing safe_level to ERB.new is deprecated. trim_mode and eoutvar
> arguments have been changed to keyword arguments. [Feature #14256]

https://bugs.ruby-lang.org/issues/14256

The following code is how they decided to make it work for multiple
versions of Ruby.

Fixes: #93.