### PR TITLE
Relax Rake dependency to < 14

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ Hoe.spec "hoe" do
   pluggable!
   require_rubygems_version ">= 1.4"
 
-  dependency "rake", [">= 0.8", "< 13.0"] # FIX: to force it to exist pre-isolate
+  dependency "rake", [">= 0.8", "< 14.0"] # FIX: to force it to exist pre-isolate
 end
 
 task :plugins do


### PR DESCRIPTION
The rake v13.0.0 already released. This fix allow to use it.
https://rubygems.org/gems/rake/versions/13.0.0

FIY: Ruby 2.7 is going to bundle v13.0.0.
https://github.com/ruby/ruby/blob/46f175ed5c8560b3c9da5ab7b4fa73287f1eb1c5/gems/bundled_gems#L5