### PR TITLE
[Metadata] Support wiki_uri and mailing_list_uri

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -121,6 +121,8 @@ class Hoe
     "doco" => "documentation_uri",
     "home" => "homepage_uri",
     "code" => "source_code_uri",
+    "wiki" => "wiki_uri",
+    "mail" => "mailing_list_uri",
   }
 
   ##

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -217,6 +217,30 @@ class TestHoe < Minitest::Test
     assert_equal exp, hoe.parse_urls(hash)
   end
 
+  def test_metadata
+    hash = [
+            "home  :: https://github.com/seattlerb/hoe",
+            "doco  :: http://docs.seattlerb.org/hoe/Hoe.pdf",
+            "clog  :: https://github.com/seattlerb/hoe/master/History.rdoc",
+            "bugs  :: https://github.com/seattlerb/hoe/issues",
+            "code  :: https://github.com/seattlerb/hoe",
+            "wiki  :: https://github.com/seattlerb/hoe/wiki",
+            "mail  :: https://github.com/seattlerb/hoe/wiki#mailing_list",
+           ].join "\n"
+
+    exp = {
+      "home" => "https://github.com/seattlerb/hoe",
+      "doco" => "http://docs.seattlerb.org/hoe/Hoe.pdf",
+      "clog" => "https://github.com/seattlerb/hoe/master/History.rdoc",
+      "bugs" => "https://github.com/seattlerb/hoe/issues",
+      "code" => "https://github.com/seattlerb/hoe",
+      "wiki" => "https://github.com/seattlerb/hoe/wiki",
+      "mail" => "https://github.com/seattlerb/hoe/wiki#mailing_list",
+    }
+
+    assert_equal exp, hoe.parse_urls(hash)
+  end
+
   def test_possibly_better
     t = Gem::Specification::TODAY
 


### PR DESCRIPTION
I found these two are new from https://guides.rubygems.org/specification-reference/#metadata.
