### PR TITLE
Fix ruby 2.7 keyword parameter warning

### DIFF
--- a/lib/hoe/debug.rb
+++ b/lib/hoe/debug.rb
@@ -91,7 +91,7 @@ module Hoe::Debug
       begin
         sh "#{DIFF} -du Manifest.txt #{f}", verbose
       ensure
-        rm f, verbose
+        rm f, **verbose
       end
     end
   end


### PR DESCRIPTION
Ruby 2.7 changed keyword parameters logic and now it generates a warning:
  warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call