### PR TITLE
Load encrypted private key using ENV['GEM_PRIVATE_KEY_PASSPHRASE'] as passphrase.

### DIFF
--- a/lib/hoe/signing.rb
+++ b/lib/hoe/signing.rb
@@ -70,7 +70,8 @@ module Hoe::Signing
     end
 
     if signing_key and cert_chain then
-      spec.signing_key = OpenSSL::PKey::RSA.new File.read signing_key
+      passphrase = ENV['GEM_PRIVATE_KEY_PASSPHRASE']
+      spec.signing_key = OpenSSL::PKey::RSA.new(File.read(signing_key), passphrase)
       spec.cert_chain = cert_chain
     end
   end


### PR DESCRIPTION
… passphrase.

This way the password can be avoided to be entered several times when building multiple gems.
It also allows parallel builds which are incompatible to interactive password prompts.

The same feature has been implemented in rubygems: https://github.com/rubygems/rubygems/commit/c1a114396fcec124d3feabf74708b4bdec02eac3