### PR TITLE
Fix minitest `test_prelude`

### DIFF
--- a/lib/hoe/test.rb
+++ b/lib/hoe/test.rb
@@ -80,8 +80,9 @@ module Hoe::Test
       when :minitest then
         require "minitest/test_task" # currently in hoe, but will move
 
+        test_prelude = self.test_prelude
         Minitest::TestTask.create :test do |t|
-          t.test_prelude = self.test_prelude
+          t.test_prelude = test_prelude
           t.libs += Hoe.include_dirs.uniq
         end
       when :testunit then

--- a/lib/minitest/test_task.rb
+++ b/lib/minitest/test_task.rb
@@ -259,8 +259,8 @@ module Minitest # :nodoc:
       tests.map! { |f| %(require "#{f}") }
 
       runner = []
-      runner << framework
       runner << test_prelude if test_prelude
+      runner << framework
       runner.concat tests
       runner = runner.join "; "
 

--- a/test/test_hoe_test.rb
+++ b/test/test_hoe_test.rb
@@ -57,7 +57,9 @@ class TestHoeTest < Minitest::Test
     assert_deprecated do
       @tester.testlib = :minitest
       autorun = %(require "minitest/autorun"; )
-      assert_equal EXPECTED % autorun, @tester.make_test_cmd
+      prelude = %(require "other/file")
+      @tester.test_prelude = prelude
+      assert_equal EXPECTED % [prelude, autorun].join("; "), @tester.make_test_cmd
     end
   end
 

--- a/test/test_hoe_test.rb
+++ b/test/test_hoe_test.rb
@@ -26,36 +26,52 @@ class TestHoeTest < Minitest::Test
     end
   end
 
-  def test_make_test_cmd_with_different_testlibs
-    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
-
-    expected = ['-w -Ilib:bin:test:. -e \'require "rubygems"; %s',
+  EXPECTED = ['-w -Ilib:bin:test:. -e \'require "rubygems"; %s',
                 'require "test/test_hoe_test.rb"',
                 "' -- ",
                ].join
 
+  def test_make_test_cmd_defaults_to_minitest
+    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
+
     # default
     assert_deprecated do
       autorun = %(require "minitest/autorun"; )
-      assert_equal expected % autorun, @tester.make_test_cmd
+      assert_equal EXPECTED % autorun, @tester.make_test_cmd
     end
+  end
+
+  def test_make_test_cmd_for_testunit
+    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
 
     assert_deprecated do
       @tester.testlib = :testunit
       testunit = %(require "test/unit"; )
-      assert_equal expected % testunit, @tester.make_test_cmd
+      assert_equal EXPECTED % testunit, @tester.make_test_cmd
     end
+  end
+
+  def test_make_test_cmd_for_minitest
+    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
 
     assert_deprecated do
       @tester.testlib = :minitest
       autorun = %(require "minitest/autorun"; )
-      assert_equal expected % autorun, @tester.make_test_cmd
+      assert_equal EXPECTED % autorun, @tester.make_test_cmd
     end
+  end
+
+  def test_make_test_cmd_for_no_framework
+    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
 
     assert_deprecated do
       @tester.testlib = :none
-      assert_equal expected % "", @tester.make_test_cmd
+      assert_equal EXPECTED % "", @tester.make_test_cmd
     end
+  end
+
+  def test_make_test_cmd_for_faketestlib
+    skip "Using TESTOPTS... skipping" if ENV["TESTOPTS"]
 
     @tester.testlib = :faketestlib
     e = assert_raises(RuntimeError) do


### PR DESCRIPTION
This PR addresses two issues:

1) In `lib/hoe/test.rb`, the use of `self.test_prelude` within a `Minitest::TestTask.create` block doesn't do what's intended, because the block is being `instance_eval`ed in the context of the `TestTask`. As a result, `t.test_prelude` is always blank, breaking `test_prelude` functionality completely. 

This PR uses a temporary variable outside the block to pass this value into the block:

```diff
+        test_prelude = self.test_prelude
         Minitest::TestTask.create :test do |t|
-          t.test_prelude = self.test_prelude
+          t.test_prelude = test_prelude
           t.libs += Hoe.include_dirs.uniq
         end
```

2) In `lib/minitest/test_task.rb` the order of the framework snippet and the prelude snippet are reversed as compared to the pre-v3.18.0 implementation.

Where previously this code put the prelude in front of the framework snippet:

```ruby
    tests = ["rubygems"]
    tests << framework if framework
    tests << test_globs.sort.map { |g| Dir.glob(g) }
    tests.flatten!
    tests.map! { |f| %(require "#{f}") }

    tests.insert 1, test_prelude if test_prelude
```

The current code reverses this sense:

```ruby
       runner = []
       runner << framework
       runner << test_prelude if test_prelude
       runner.concat tests
       runner = runner.join "; "
```

This PR restores the original order, which as it turns out is critical to getting SimpleCov to work with Minitest. (See https://github.com/sparklemotion/nokogiri/issues/1965 for the SimpleCov-related problem that spawned this particular yak shave!)