### PR TITLE
only intuit values if needed

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -223,6 +223,13 @@ class Hoe
   attr_accessor :group_name
 
   ##
+  # Optional: The homepage of the project. Auto-populates to the home key
+  # of the urls read from the README.txt
+  #
+
+  attr_accessor :homepage
+
+  ##
   # The Gem::Specification.
 
   attr_accessor :spec # :nodoc:
@@ -525,7 +532,7 @@ class Hoe
       s.version              = version if version
       s.summary              = summary
       s.email                = email
-      s.homepage             = urls["home"] || urls.values.first
+      s.homepage             ||= urls["home"] || urls.values.first
       s.description          = description
       s.files                = manifest
       s.executables          = s.files.grep(/^bin/) { |f| File.basename(f) }
@@ -810,12 +817,15 @@ class Hoe
 
   def post_initialize
     activate_plugin_deps
-    intuit_values File.read_utf readme_file if readme_file
+    unless skip_intuit_values?
+      intuit_values File.read_utf readme_file if readme_file
+    end
     validate_fields
     define_spec
     load_plugin_tasks
     add_dependencies
   end
+
 
   ##
   # Reads Manifest.txt and returns an Array of lines in the manifest.
@@ -894,6 +904,14 @@ class Hoe
       value = self.send(field)
       abort "Hoe #{field} value not set. aborting" if value.nil? or value.empty?
     end
+  end
+
+  def skip_intuit_values?
+    %w[summary description homepage].each do |field|
+      value = self.send(field)
+      return false if value.nil? or value.empty?
+    end
+    true
   end
 
   ##

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -222,6 +222,12 @@ class Hoe
 
   attr_accessor :group_name
 
+
+  ##
+  # Optional: The name of the executables directory. [default: bin]
+
+  attr_accessor :bindir
+
   ##
   # Optional: The homepage of the project. Auto-populates to the home key
   # of the urls read from the README.txt
@@ -535,8 +541,8 @@ class Hoe
       s.homepage             ||= urls["home"] || urls.values.first
       s.description          = description
       s.files                = manifest
-      s.executables          = s.files.grep(/^bin/) { |f| File.basename(f) }
-      s.bindir               = "bin"
+      s.executables          = s.files.grep(/^#{bindir}/) { |f| File.basename(f) }
+      s.bindir               = bindir || "bin"
       s.require_paths        = dirs unless dirs.empty?
       s.rdoc_options         = ["--main", readme_file]
       s.post_install_message = post_install_message

--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -538,17 +538,18 @@ class Hoe
       s.version              = version if version
       s.summary              = summary
       s.email                = email
-      s.homepage             ||= urls["home"] || urls.values.first
+      s.homepage             = homepage || urls["home"] || urls.values.first
+      
       s.description          = description
       s.files                = manifest
-      s.executables          = s.files.grep(/^#{bindir}/) { |f| File.basename(f) }
       s.bindir               = bindir || "bin"
+      s.executables          = s.files.grep(/^#{bindir}/) { |f| File.basename(f) }
       s.require_paths        = dirs unless dirs.empty?
       s.rdoc_options         = ["--main", readme_file]
       s.post_install_message = post_install_message
       s.metadata             = (urls.keys & URLS_TO_META_MAP.keys).map { |name|
-        [URLS_TO_META_MAP[name], urls[name]]
-      }.to_h
+        [URLS_TO_META_MAP[name], urls[name]] 
+      }.to_h if urls
 
       missing "Manifest.txt" if s.files.empty?
 

--- a/test/test_hoe.rb
+++ b/test/test_hoe.rb
@@ -150,7 +150,6 @@ class TestHoe < Minitest::Test
         File.write "Manifest.txt", "FAQ.rdoc\nHistory.rdoc\nREADME.rdoc\n"
         File.write "README.rdoc", "= blah\n\nhome :: http://blah/"
         File.write "History.rdoc", "=== 1.0"
-
         assert_equal "History.rdoc", hoe.history_file
         assert_equal "README.rdoc", hoe.readme_file
         assert_equal %w[FAQ.rdoc History.rdoc README.rdoc],
@@ -171,6 +170,7 @@ class TestHoe < Minitest::Test
       end
     end
   end
+
 
   def test_file_read_utf
     Tempfile.open "BOM" do |io|
@@ -295,6 +295,30 @@ class TestHoe < Minitest::Test
     end
 
     assert_equal exp, h.urls
+  end
+
+  def test_intuit_values_should_be_silent_if_summary_description_and_homepage_are_set
+    h = nil
+    readme = <<~EOM
+    == this is readme
+
+    == description
+    this is a bogus description
+   EOM
+
+    assert_silent do
+      h = Hoe.spec "blah" do
+        developer "auther", "email"
+        license "MIT"
+        self.homepage = 'http://myhome'
+        self.description = 'this is real description'
+        self.summary = 'this is summary'
+      end
+    end
+
+    assert_equal h.homepage , 'http://myhome'
+    assert_equal h.description , 'this is real description'
+    assert_equal h.summary , 'this is summary'
   end
 
   def test_metadata


### PR DESCRIPTION
check for homepage, summary and description and only intuit values if they are
not set.  Useful if setting these in a different readme format.