### PR TITLE
Support Jruby + Windows

### DIFF
--- a/lib/hoe.rb
+++ b/lib/hoe.rb
@@ -708,7 +708,7 @@ class Hoe
   # should update the readme.
 
   def parse_urls text
-    lines = text.gsub(/^\* /, "").delete("<>").split(/\n/).grep(/\S+/)
+    lines = text.gsub(/^\* /, "").delete("<>").lines.map(&:chomp).grep(/\S+/)
 
     if lines.first =~ /::/ then
       Hash[lines.map { |line| line.split(/\s*::\s*/) }]

--- a/lib/hoe/debug.rb
+++ b/lib/hoe/debug.rb
@@ -70,7 +70,6 @@ module Hoe::Debug
   # Verifies your Manifest.txt against the files in your project.
 
   def check_manifest
-    f = "Manifest.tmp"
     require "find"
     files = []
     with_config do |config, _|
@@ -82,17 +81,14 @@ module Hoe::Debug
         files << path[2..-1]
       end
 
-      files = files.sort.join "\n"
+      files = files.sort
+      manifest_files = File.readlines("Manifest.txt").map(&:chomp).sort
 
-      File.open f, "wb" do |fp| fp.puts files end
+      added_files = files - manifest_files
+      raise "#{added_files} need to be added to the manifest" if added_files.any?
 
-      verbose = { :verbose => Rake.application.options.verbose }
-
-      begin
-        sh "#{DIFF} -du Manifest.txt #{f}", verbose
-      ensure
-        rm f, **verbose
-      end
+      removed_files = manifest_files - files
+      raise "#{removed_files} need to be removed to the manifest" if removed_files.any?
     end
   end
 end

--- a/lib/hoe/debug.rb
+++ b/lib/hoe/debug.rb
@@ -84,7 +84,7 @@ module Hoe::Debug
 
       files = files.sort.join "\n"
 
-      File.open f, "w" do |fp| fp.puts files end
+      File.open f, "wb" do |fp| fp.puts files end
 
       verbose = { :verbose => Rake.application.options.verbose }
 

--- a/lib/hoe/package.rb
+++ b/lib/hoe/package.rb
@@ -92,9 +92,9 @@ module Hoe::Package
     null_dev = Hoe::WINDOZE ? "> NUL 2>&1" : "> /dev/null 2>&1"
 
     gem_cmd = Gem.default_exec_format % "gem"
-    sudo    = "sudo "                  unless should_not_sudo
-    local   = "--local"                unless version
-    version = "--version '#{version}'" if     version
+    sudo    = "sudo "                   unless should_not_sudo
+    local   = "--local"                 unless version
+    version = %(--version "#{version}") if     version
 
     cmd  = "#{sudo}#{gem_cmd} install #{local} #{name} #{version}"
     cmd += " --no-document" unless rdoc

--- a/lib/minitest/test_task.rb
+++ b/lib/minitest/test_task.rb
@@ -104,7 +104,7 @@ module Minitest # :nodoc:
 
     def initialize name = :test # :nodoc:
       self.extra_args   = []
-      self.framework    = %(require "minitest/autorun")
+      self.framework    = %(require 'minitest/autorun')
       self.libs         = %w[lib test .]
       self.name         = name
       self.test_globs   = ["test/**/{test,spec}_*.rb",
@@ -256,7 +256,7 @@ module Minitest # :nodoc:
     def make_test_cmd globs = test_globs
       tests = []
       tests.concat Dir[*globs].sort.shuffle # TODO: SEED -> srand first?
-      tests.map! { |f| %(require "#{f}") }
+      tests.map! { |f| %(require '#{f}') }
 
       runner = []
       runner << test_prelude if test_prelude
@@ -268,7 +268,7 @@ module Minitest # :nodoc:
       args << "-I#{libs.join(File::PATH_SEPARATOR)}" unless libs.empty?
       args << "-w" if warning
       args << '-e'
-      args << "'#{runner}'"
+      args << "\"#{runner}\""
       args << '--'
       args << extra_args.map(&:shellescape)
 

--- a/test/test_hoe_debug.rb
+++ b/test/test_hoe_debug.rb
@@ -64,9 +64,9 @@ class TestHoeDebug < Minitest::Test
         end
       end
 
-      assert_match %r%^Command failed with status%, e.message
-      assert_match %r%^\+missing.rb%, out
+      assert_match %r%^\["missing.rb"\] need to be added to the manifest%, e.message
       assert_equal "", err
+      assert_equal "", out
     end
   end
 

--- a/test/test_hoe_test.rb
+++ b/test/test_hoe_test.rb
@@ -31,7 +31,7 @@ class TestHoeTest < Minitest::Test
                 --].join(" ") + " "
 
   MT_EXPECTED = %W[-Ilib:test:. -w
-                   -e '%srequire "test/test_hoe_test.rb"'
+                   -e "%srequire 'test/test_hoe_test.rb'"
                    --].join(" ") + " "
 
   def test_make_test_cmd_defaults_to_minitest
@@ -59,7 +59,7 @@ class TestHoeTest < Minitest::Test
 
     require "minitest/test_task" # currently in hoe, but will move
 
-    framework = %(require "minitest/autorun"; )
+    framework = %(require 'minitest/autorun'; )
 
     @tester = Minitest::TestTask.create :test do |t|
       t.libs += Hoe.include_dirs.uniq
@@ -74,8 +74,8 @@ class TestHoeTest < Minitest::Test
 
     require "minitest/test_task" # currently in hoe, but will move
 
-    prelude = %(require "other/file")
-    framework = %(require "minitest/autorun"; )
+    prelude = %(require 'other/file')
+    framework = %(require 'minitest/autorun'; )
 
     @tester = Minitest::TestTask.create :test do |t|
       t.test_prelude = prelude


### PR DESCRIPTION
Hello! :wave: :wave:

This a bit of rabbit hole. We caused [a regression on JRuby + Windows](https://github.com/rubygems/rubygems/issues/4129) when we released bundler 2.2. The cause of the issue was that we upgraded the `net-http-persistent` library that bundler vendors, and the new version included a regression on this platform. To remediate the issue, [we patched our vendored version and added a bare JRuby + Windows CI](https://github.com/rubygems/rubygems/pull/4138).

As further steps, we want to upstream the fix that we added to net-http-persistent, but found that this library doesn't have a JRuby + Windows CI either. So I want to add such CI to that library first, so that the fix can be covered. This is the PR where I propose that: https://github.com/drbrain/net-http-persistent/pull/125.

However, net-http-persistent uses hoe, and it turns out hoe doesn't support JRuby + Windows either, so I had to add a few patches to `hoe` to get that PR passing.

These is the set of patches that I added. The PR is not ready, it'd need at least some tests and better explanations for each patch, but I wanted to share them so I don't forget to follow up in the future, or in case the maintainers here want to tackle some of them themselves.

Thanks!