### PR TITLE
Fix NoMethodError: undefined method 'verbose'

### DIFF
--- a/lib/hoe/debug.rb
+++ b/lib/hoe/debug.rb
@@ -86,7 +86,7 @@ module Hoe::Debug
 
       File.open f, "w" do |fp| fp.puts files end
 
-      verbose = { :verbose => Rake.application.options.verbose }
+      verbose = { :verbose => Rake.verbose }
 
       begin
         sh "#{DIFF} -du Manifest.txt #{f}", verbose

--- a/test/test_hoe_debug.rb
+++ b/test/test_hoe_debug.rb
@@ -7,8 +7,8 @@ class TestHoeDebug < Minitest::Test
 
   include Hoe::Debug
 
-  # On Rake 0.8.7 verbose_flag is true, causing two tests to fail.
-  RakeFileUtils.verbose_flag = nil
+  # On Rake 0.8.7 verbose_flag is true, causing three tests to fail.
+  Rake.verbose(false)
 
   attr_accessor :generated_files
 


### PR DESCRIPTION
With rake 13.2.0, Rake.application.options is not an OpenStruct anymore and contains only valid options. The verbose flag can be queried with Rake.verbose.

See also https://github.com/ruby/rake/pull/545