### PR TITLE
Fix Gem index inflation

### DIFF
--- a/lib/hoe/deps.rb
+++ b/lib/hoe/deps.rb
@@ -154,7 +154,7 @@ module Hoe::Deps
              warn "Fetching full index and caching. This can take a while."
              url = GEMURL + "Marshal.#{Gem.marshal_version}.Z"
              dump = Gem::RemoteFetcher.fetcher.fetch_path url
-             dump = Gem.inflate dump
+             dump = Gem::Util.inflate dump
 
              warn "stripping index to latest gems"
              ary = Marshal.load dump


### PR DESCRIPTION
The Rubygems team moved `Gem.inflate` to `Gem::Util.inflate`, without which deps index retrieval doesn't work.